### PR TITLE
Improve PackageName parsing from manifest

### DIFF
--- a/cmd/mendix-userlib-cleaner/main.go
+++ b/cmd/mendix-userlib-cleaner/main.go
@@ -201,7 +201,8 @@ func parseManifest(filePath string, text string) JarProperties {
 
 		key := pair[0]
 		value := pair[1]
-		if key == "Bundle-SymbolicName" || key == "Extension-Name" {
+		// Automatic-Module-Name - used in org.apache.httpcomponents.httpclient / org.apache.httpcomponents.client5.httpclient5
+		if key == "Bundle-SymbolicName" || key == "Extension-Name" || key == "Automatic-Module-Name" {
 			jarProp.packageName = value
 		} else if key == "Bundle-Version" || key == "Implementation-Version" {
 			jarProp.version = value
@@ -216,7 +217,10 @@ func parseManifest(filePath string, text string) JarProperties {
 				continue
 			}
 			jarProp.name = value
-			jarProp.packageName = value
+			if jarProp.packageName == "" {
+				// only use Bundle-Name as packageName if no alternative exists
+				jarProp.packageName = value
+			}
 		}
 	}
 	return jarProp


### PR DESCRIPTION
read 'Automatic-Module-Name' (used in apache http) and only use 'Bundle-Name' if no other is found (prevent deletion of commons-collections-3.x due to commons-collections4 / prevent deletion of httpcore-4.x due to httpcore5-5.x)